### PR TITLE
Issue 3: Add timeline store and diff model for tracer events 

### DIFF
--- a/Lib/idlelib/idle_test/test_timeline_store.py
+++ b/Lib/idlelib/idle_test/test_timeline_store.py
@@ -1,0 +1,80 @@
+"""Tests for idlelib.timeline_store."""
+
+from __future__ import annotations
+
+import unittest
+
+from idlelib.timeline_store import TimelineStore, diff
+
+
+class _BadEq:
+    def __eq__(self, other):
+        raise RuntimeError("cannot compare")
+
+
+class _BadRepr:
+    def __repr__(self):
+        raise RuntimeError("cannot repr")
+
+    def __eq__(self, other):
+        raise RuntimeError("cannot compare")
+
+
+class TimelineStoreTest(unittest.TestCase):
+    def test_store_event_and_get_step_ordering(self):
+        store = TimelineStore()
+        first = {"step": 1, "locals": {"a": "1"}}
+        second = {"step": 2, "locals": {"a": "2"}}
+
+        store.store_event(first)
+        store.store_event(second)
+
+        self.assertEqual(store.get_step(0)["step"], 1)
+        self.assertEqual(store.get_step(1)["step"], 2)
+
+    def test_get_step_out_of_range_raises_index_error(self):
+        store = TimelineStore()
+        store.store_event({"step": 1, "locals": {"a": "1"}})
+
+        with self.assertRaises(IndexError):
+            store.get_step(99)
+
+    def test_diff_detects_added_removed_changed(self):
+        prev = {"a": "1", "b": "2"}
+        curr = {"b": "3", "c": "4"}
+
+        result = diff(prev, curr)
+        self.assertEqual(result["added"], {"c": "4"})
+        self.assertEqual(result["removed"], {"a": "1"})
+        self.assertEqual(result["changed"], {"b": {"before": "2", "after": "3"}})
+
+    def test_diff_steps_uses_locals_snapshot(self):
+        store = TimelineStore()
+        store.store_event({"step": 1, "locals": {"x": "10", "y": "20"}})
+        store.store_event({"step": 2, "locals": {"x": "11", "z": "30"}})
+
+        result = store.diff_steps(0, 1)
+        self.assertEqual(result["added"], {"z": "30"})
+        self.assertEqual(result["removed"], {"y": "20"})
+        self.assertEqual(result["changed"], {"x": {"before": "10", "after": "11"}})
+
+    def test_diff_steps_handles_missing_or_non_mapping_locals(self):
+        store = TimelineStore()
+        store.store_event({"step": 1, "locals": None})
+        store.store_event({"step": 2, "locals": 123})
+
+        result = store.diff_steps(0, 1)
+        self.assertEqual(result["added"], {})
+        self.assertEqual(result["removed"], {})
+        self.assertEqual(result["changed"], {})
+
+    def test_diff_handles_unusual_values_without_crashing(self):
+        result = diff({"k": _BadEq()}, {"k": _BadRepr()})
+        self.assertIn("k", result["changed"])
+        self.assertIn("before", result["changed"]["k"])
+        self.assertIn("after", result["changed"]["k"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+

--- a/Lib/idlelib/timeline_store.py
+++ b/Lib/idlelib/timeline_store.py
@@ -1,0 +1,97 @@
+"""Timeline store and diff helpers for TraceLab.
+
+This module is intentionally UI-agnostic and consumes plain event dictionaries
+from idlelib.timeline_tracer (or compatible producers).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+DiffResult = dict[str, dict[str, Any]]
+
+
+def _safe_repr(value: Any) -> str:
+    try:
+        return repr(value)
+    except Exception as exc:
+        return f"<unreprable {type(value).__name__}: {exc!r}>"
+
+
+def _values_equal(left: Any, right: Any) -> bool:
+    """Compare two values without allowing unusual __eq__ to crash diffing."""
+    try:
+        return left == right
+    except Exception:
+        return _safe_repr(left) == _safe_repr(right)
+
+
+def _snapshot_from_event(event: Mapping[str, Any], *, namespace: str) -> dict[str, Any]:
+    raw = event.get(namespace, {})
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    return {}
+
+
+def diff(prev: Mapping[str, Any] | None, curr: Mapping[str, Any] | None) -> DiffResult:
+    """Compute added/removed/changed keys between two snapshots.
+
+    Returns:
+        {
+            "added": {name: value},
+            "removed": {name: value},
+            "changed": {name: {"before": old, "after": new}},
+        }
+    """
+    prev_map = dict(prev or {})
+    curr_map = dict(curr or {})
+
+    prev_keys = set(prev_map)
+    curr_keys = set(curr_map)
+
+    added = {name: curr_map[name] for name in curr_keys - prev_keys}
+    removed = {name: prev_map[name] for name in prev_keys - curr_keys}
+
+    changed: dict[str, Any] = {}
+    for name in prev_keys & curr_keys:
+        before = prev_map[name]
+        after = curr_map[name]
+        if not _values_equal(before, after):
+            changed[name] = {"before": before, "after": after}
+
+    return {
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+    }
+
+
+class TimelineStore:
+    """Store timeline events and provide step retrieval + diff access."""
+
+    def __init__(self, *, namespace: str = "locals") -> None:
+        self._events: list[dict[str, Any]] = []
+        self._namespace = namespace
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def store_event(self, event: Mapping[str, Any]) -> None:
+        self._events.append(dict(event))
+
+    def get_step(self, i: int) -> dict[str, Any]:
+        # Uses list indexing semantics; raises IndexError when out of range.
+        return self._events[i]
+
+    def get_events(self) -> list[dict[str, Any]]:
+        return list(self._events)
+
+    def diff_steps(self, i: int, j: int) -> DiffResult:
+        prev_event = self.get_step(i)
+        curr_event = self.get_step(j)
+        prev_snapshot = _snapshot_from_event(prev_event, namespace=self._namespace)
+        curr_snapshot = _snapshot_from_event(curr_event, namespace=self._namespace)
+        return diff(prev_snapshot, curr_snapshot)
+


### PR DESCRIPTION
## Summary
- Add a new UI-agnostic timeline storage module at `Lib/idlelib/timeline_store.py`.
- Implement step/event APIs and deterministic diffing for locals snapshots:
  - `store_event(event)`
  - `get_step(i)` (0-based, raises `IndexError` if out of range)
  - `diff(prev, curr)` and `diff_steps(i, j)`
- Add tests at `Lib/idlelib/idle_test/test_timeline_store.py` for ordering, out-of-range behavior, diff correctness, and edge-case safety.

## Why
Issue #2 provides raw per-line trace events; this PR adds the model layer that converts those events into a stable, UI-ready timeline contract (`added`, `removed`, `changed`) for Issue #4.

## Behavior / Contract
- Default diff scope is `locals`.
- Diff result shape:
  - `added: {name: value}`
  - `removed: {name: value}`
  - `changed: {name: {"before": old, "after": new}}`
- Non-mapping or missing snapshot namespaces are handled gracefully (treated as empty snapshots).
- Unusual value comparison/repr cases are handled defensively to avoid crashes.

## Tests
- Added: `idlelib.idle_test.test_timeline_store`
- Re-validated with existing tracer test:
  - `idlelib.idle_test.test_timeline_tracer`

## Scope Notes
- No debugger/UI integration changes in this PR.
- No changes to `debugger.py` or timeline UI modules; this is storage/model only.