### PR TITLE
 Implemented Issue 3 - AST-based unit test discovery feature

### DIFF
--- a/Lib/idlelib/idle_test/test_testrunner_discovery.py
+++ b/Lib/idlelib/idle_test/test_testrunner_discovery.py
@@ -1,0 +1,214 @@
+"""Test testrunner_discovery module."""
+
+import os
+import tempfile
+import unittest
+
+from idlelib.testrunner_discovery import discover_tests
+
+
+class TestDiscoverTests(unittest.TestCase):
+    """Tests for discover_tests function (AST-based discovery)."""
+    
+    def setUp(self):
+        """Create a temporary directory for test fixture files."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+    
+    def _write_temp_file(self, filename: str, code: str) -> str:
+        """Write Python code to a temporary file and return its path.
+        
+        Args:
+            filename: Name of the file (e.g., 'simple.py')
+            code: Python code to write
+        
+        Returns:
+            Absolute path to the created file
+        """
+        path = os.path.join(self.temp_dir.name, filename)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(code)
+        return path
+    
+    def test_discovers_single_test_class(self):
+        """Test discovery of a simple unittest.TestCase with multiple methods."""
+        code = '''\
+import unittest
+
+class TestExample(unittest.TestCase):
+    def test_foo(self):
+        pass
+    
+    def test_bar(self):
+        pass
+'''
+        path = self._write_temp_file('simple.py', code)
+        results = discover_tests(path)
+        
+        # Should find 2 test methods
+        self.assertEqual(len(results), 2)
+        
+        # Check structure of results
+        for result in results:
+            self.assertIn('id', result)
+            self.assertIn('module', result)
+            self.assertIn('class', result)
+            self.assertIn('method', result)
+        
+        # Verify content
+        ids = {r['id'] for r in results}
+        self.assertIn('simple.TestExample.test_bar', ids)
+        self.assertIn('simple.TestExample.test_foo', ids)
+    
+    def test_empty_file_returns_empty_list(self):
+        """Test that a file with no tests returns an empty list."""
+        code = '# Just a comment\nprint("hello")\n'
+        path = self._write_temp_file('empty.py', code)
+        results = discover_tests(path)
+        self.assertEqual(results, [])
+    
+    def test_ignores_non_testcase_classes(self):
+        """Test that non-TestCase classes are ignored."""
+        code = '''\
+import unittest
+
+class NotATest:
+    """Regular class with test_* methods (should be ignored)."""
+    def test_method(self):
+        pass
+
+class TestReal(unittest.TestCase):
+    """Actual test class."""
+    def test_real(self):
+        pass
+'''
+        path = self._write_temp_file('mixed.py', code)
+        results = discover_tests(path)
+        
+        # Should only find the test in TestReal
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['class'], 'TestReal')
+        self.assertEqual(results[0]['method'], 'test_real')
+    
+    def test_handles_malformed_file_gracefully(self):
+        """Test that syntax errors are handled gracefully."""
+        code = 'def broken( syntax error\n'
+        path = self._write_temp_file('broken.py', code)
+        results = discover_tests(path)
+        # Should return empty list, not raise exception
+        self.assertEqual(results, [])
+    
+    def test_dict_has_required_fields(self):
+        """Test that returned dicts have all required fields."""
+        code = '''\
+import unittest
+
+class TestExample(unittest.TestCase):
+    def test_example(self):
+        pass
+'''
+        path = self._write_temp_file('fields.py', code)
+        results = discover_tests(path)
+        
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        
+        # Verify all required fields are present
+        required_fields = {'id', 'module', 'class', 'method'}
+        self.assertEqual(set(result.keys()), required_fields)
+        
+        # Verify values
+        self.assertEqual(result['module'], 'fields')
+        self.assertEqual(result['class'], 'TestExample')
+        self.assertEqual(result['method'], 'test_example')
+        self.assertEqual(result['id'], 'fields.TestExample.test_example')
+    
+    def test_results_sorted_by_id(self):
+        """Test that results are sorted by ID for determinism."""
+        code = '''\
+import unittest
+
+class TestZ(unittest.TestCase):
+    def test_z(self):
+        pass
+    
+    def test_a(self):
+        pass
+
+class TestA(unittest.TestCase):
+    def test_b(self):
+        pass
+'''
+        path = self._write_temp_file('sorted.py', code)
+        results = discover_tests(path)
+        
+        # Extract IDs and verify they are sorted
+        ids = [r['id'] for r in results]
+        sorted_ids = sorted(ids)
+        self.assertEqual(ids, sorted_ids)
+    
+    def test_discovers_testcase_without_import(self):
+        """Test discovery when TestCase is used directly (not via unittest.*)."""
+        code = '''\
+from unittest import TestCase
+
+class TestDirect(TestCase):
+    def test_method(self):
+        pass
+'''
+        path = self._write_temp_file('direct.py', code)
+        results = discover_tests(path)
+        
+        # Should discover the test
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['class'], 'TestDirect')
+    
+    def test_discovers_qualified_testcase(self):
+        """Test discovery when TestCase is qualified as unittest.TestCase."""
+        code = '''\
+import unittest
+
+class TestQualified(unittest.TestCase):
+    def test_qualified(self):
+        pass
+'''
+        path = self._write_temp_file('qualified.py', code)
+        results = discover_tests(path)
+        
+        # Should discover the test
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['class'], 'TestQualified')
+    
+    def test_ignores_non_test_methods(self):
+        """Test that methods not starting with 'test_' are ignored."""
+        code = '''\
+import unittest
+
+class TestExample(unittest.TestCase):
+    def test_real_test(self):
+        pass
+    
+    def helper_method(self):
+        pass
+    
+    def setUp(self):
+        pass
+    
+    def tearDown(self):
+        pass
+'''
+        path = self._write_temp_file('methods.py', code)
+        results = discover_tests(path)
+        
+        # Should only find test_real_test
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['method'], 'test_real_test')
+    
+    def test_nonexistent_file_returns_empty_list(self):
+        """Test that a nonexistent file returns an empty list gracefully."""
+        results = discover_tests('/nonexistent/path/file.py')
+        self.assertEqual(results, [])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/Lib/idlelib/testrunner_discovery.py
+++ b/Lib/idlelib/testrunner_discovery.py
@@ -1,0 +1,118 @@
+"""Unittest discovery via AST (no code execution).
+
+This module provides safe, deterministic test discovery by parsing Python
+files with the ast module, without executing any code. It extracts unittest
+test identifiers from TestCase subclasses and test_* methods.
+
+Functions:
+    discover_tests(file_path: str) -> list[dict]
+        Find and return unittest test identifiers in a Python file.
+"""
+
+import ast
+import os
+from typing import Any
+
+
+def discover_tests(file_path: str) -> list[dict]:
+    """Discover unittest tests in a Python file using AST parsing.
+    
+    Scans a Python file for unittest.TestCase subclasses and returns
+    a list of discovered test methods without executing any code.
+    
+    Args:
+        file_path: Path to a .py file (absolute or relative).
+    
+    Returns:
+        List of dicts, each with keys:
+            - id: Fully qualified test ID (e.g., "module.ClassName.method_name")
+            - module: Module name (derived from file basename without .py)
+            - class: Class name (e.g., "TestExample")
+            - method: Method name (e.g., "test_foo")
+        
+        Sorted by 'id' for determinism. Empty list if file has no tests,
+        syntax error, or file not found.
+    
+    Examples:
+        >>> discover_tests("test_sample.py")
+        [
+            {
+                "id": "test_sample.TestExample.test_foo",
+                "module": "test_sample",
+                "class": "TestExample",
+                "method": "test_foo"
+            }
+        ]
+    """
+    try:
+        # Validate file exists
+        if not os.path.isfile(file_path):
+            return []
+        
+        # Read file content
+        with open(file_path, 'r', encoding='utf-8') as f:
+            code = f.read()
+        
+        # Parse into AST
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            # Silently return empty list for malformed files
+            return []
+        
+        # Derive module name from file path
+        basename = os.path.basename(file_path)
+        module_name = os.path.splitext(basename)[0]
+        
+        # Discover test classes and methods
+        tests = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                # Check if class inherits from TestCase
+                if _inherits_from_testcase(node):
+                    # Collect test methods
+                    for item in node.body:
+                        if isinstance(item, ast.FunctionDef):
+                            if item.name.startswith('test_'):
+                                test_dict = {
+                                    'id': f"{module_name}.{node.name}.{item.name}",
+                                    'module': module_name,
+                                    'class': node.name,
+                                    'method': item.name,
+                                }
+                                tests.append(test_dict)
+        
+        # Sort by id for determinism
+        tests.sort(key=lambda t: t['id'])
+        
+        return tests
+    
+    except Exception:
+        # Catch any unexpected errors and return empty list
+        return []
+
+
+def _inherits_from_testcase(class_node: ast.ClassDef) -> bool:
+    """Check if a ClassDef node inherits from unittest.TestCase.
+    
+    Handles common patterns:
+        - TestCase (direct reference)
+        - unittest.TestCase (qualified reference)
+    
+    Args:
+        class_node: ast.ClassDef node to check.
+    
+    Returns:
+        True if any base is TestCase or unittest.TestCase, False otherwise.
+    """
+    for base in class_node.bases:
+        # Direct name reference: TestCase
+        if isinstance(base, ast.Name):
+            if base.id == 'TestCase':
+                return True
+        # Attribute reference: unittest.TestCase
+        elif isinstance(base, ast.Attribute):
+            if base.attr == 'TestCase':
+                return True
+    
+    return False


### PR DESCRIPTION
## Issue 3: Test Discovery - AST-based unittest discovery

### Overview
Added test discovery using AST parsing so we can find unittest tests without actually running any code. This keeps things safe and predictable for developers. 

### What's New
Files Added:
- Lib/idlelib/testrunner_discovery.py - Main discovery function
- Lib/idlelib/idle_test/test_testrunner_discovery.py - Tests (10 total, all passing)

Basic Usage:
from idlelib.testrunner_discovery import discover_tests
results = discover_tests('path/to/test_file.py')
Returns: [{"id": "...", "module": "...", "class": "...", "method": "..."}, ...]

### How It Works
It parses the Python file to find classes that inherit from TestCase, grabs any methods starting with test_, and returns them as a sorted list. No code gets executed during discovery, which is the whole point.

### Testing
Run the tests with:
./python.exe -m unittest idlelib.idle_test.test_testrunner_discovery -v

The tests cover the basics (finding tests in TestCase classes) plus cases like empty files, syntax errors, and missing files.

### Acceptance Criteria
- Discovers tests from unittest.TestCase subclasses
- Returns empty list when there's no tests (no crashes)
- Has unit tests
- No UI components, output is pickleable
- Uses AST for safe parsing

### Quick Notes
- Use ./python.exe from the repo to avoid version conflicts with system Python
- Only uses stdlib modules (ast and os)
- Results are always sorted by ID so they're predictable