### PR TITLE
Feat/timeline user event filter

### DIFF
--- a/Lib/idlelib/idle_test/test_timeline_controller.py
+++ b/Lib/idlelib/idle_test/test_timeline_controller.py
@@ -1,0 +1,62 @@
+"""Tests for idlelib.timeline_controller."""
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    from idlelib.timeline_controller import TimelineController
+except Exception:
+    from timeline_controller import TimelineController  # type: ignore[no-redef]
+
+
+class _DummyInterp:
+    rpcclt = None
+
+
+class _DummyPyShell:
+    interp = _DummyInterp()
+
+
+class TimelineControllerFilterTest(unittest.TestCase):
+    def setUp(self):
+        self.controller = TimelineController(_DummyPyShell())
+
+    def test_excludes_idlelib_paths(self):
+        event = {"filename": "/repo/Lib/idlelib/rpc.py"}
+        self.assertFalse(self.controller._is_user_event(event))
+
+    def test_excludes_stdlib_paths(self):
+        event = {"filename": "/opt/homebrew/Cellar/python@3.15/lib/python3.15/threading.py"}
+        self.assertFalse(self.controller._is_user_event(event))
+
+    def test_excludes_site_packages(self):
+        event = {"filename": "/env/lib/python3.11/site-packages/pkg/mod.py"}
+        self.assertFalse(self.controller._is_user_event(event))
+
+    def test_excludes_angle_bracket_filenames(self):
+        event = {"filename": "<frozen importlib._bootstrap>"}
+        self.assertFalse(self.controller._is_user_event(event))
+
+    def test_keeps_user_script(self):
+        event = {"filename": "/Users/me/project/Test_Script.py"}
+        self.assertTrue(self.controller._is_user_event(event))
+
+    def test_prefer_user_events_filters_internals(self):
+        events = [
+            {"filename": "/repo/Lib/idlelib/rpc.py", "lineno": 1},
+            {"filename": "/opt/homebrew/lib/python3.15/threading.py", "lineno": 2},
+            {"filename": "/Users/me/Test.py", "lineno": 3},
+        ]
+        out = self.controller._prefer_user_events(events)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["filename"], "/Users/me/Test.py")
+
+    def test_prefer_user_events_returns_empty_when_no_user_events(self):
+        events = [{"filename": "/repo/Lib/idlelib/rpc.py", "lineno": 1}]
+        out = self.controller._prefer_user_events(events)
+        self.assertEqual(out, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Lib/idlelib/idle_test/test_timeline_flow_verbose.py
+++ b/Lib/idlelib/idle_test/test_timeline_flow_verbose.py
@@ -1,0 +1,125 @@
+"""Test that prints the data passed at each step of the timeline feature.
+
+Run with the project's Python (e.g. from repo root):
+  ./build-macos/python.exe -m idlelib.idle_test.test_timeline_flow_verbose -v
+
+This test runs a minimal timeline flow (tracer -> filter -> pipeline)
+and prints the actual structures at each stage so you can see what is passed
+around when the user uses the timeline feature.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pprint import pprint
+
+# Ensure we can import idlelib when run as __main__ or from different cwds.
+if __name__ == "__main__":
+    _lib = os.path.join(os.path.dirname(__file__), "..", "..")
+    _lib = os.path.abspath(_lib)
+    if _lib not in sys.path:
+        sys.path.insert(0, _lib)
+
+try:
+    from idlelib.timeline_tracer import TimelineTracer
+    from idlelib.timeline_pipeline import events_to_steps
+except Exception:
+    from timeline_tracer import TimelineTracer
+    from timeline_pipeline import events_to_steps
+
+# Optional: use controller's filter if available (needs tkinter).
+def _filter_user_events(events, script_path: str):
+    """Keep events for the given script path (simulates controller selection)."""
+    want = os.path.normcase(os.path.abspath(script_path))
+    out = []
+    for e in events:
+        fn = e.get("filename")
+        if isinstance(fn, str) and fn and os.path.normcase(os.path.abspath(fn)) == want:
+            out.append(e)
+    return out if out else events
+
+
+# Small script that produces a few trace events with changing locals.
+# Filename is set to "demo_script.py" so controller treats it as user code.
+_DEMO_SCRIPT = """
+x = 1
+y = 2
+z = x + y
+def f():
+    a = 10
+    b = 20
+    return a + b
+result = f()
+"""
+
+
+class _DummyInterp:
+    rpcclt = None
+
+
+class _DummyPyShell:
+    interp = _DummyInterp()
+
+
+class TimelineFlowVerboseTest(unittest.TestCase):
+    """Run timeline flow and print data at each step (for inspection)."""
+
+    def test_timeline_flow_prints_data_at_each_step(self) -> None:
+        # Use a real path so controller filter keeps these events
+        script_path = os.path.abspath("demo_script.py")
+
+        tracer = TimelineTracer(max_events=500)
+        tracer.start()
+        try:
+            exec(compile(_DEMO_SCRIPT, script_path, "exec"), {})
+        finally:
+            tracer.stop()
+
+        raw_events = tracer.get_events()
+        self.assertGreater(len(raw_events), 0, "tracer should capture events")
+
+        # --- Step 1: Raw events from tracer ---
+        print("\n" + "=" * 60)
+        print("STEP 1: Raw events from tracer (get_events())")
+        print("=" * 60)
+        print(f"Count: {len(raw_events)}")
+        print("\nFirst event (full):")
+        pprint(raw_events[0])
+        if len(raw_events) > 1:
+            print("\nLast event (full):")
+            pprint(raw_events[-1])
+        print()
+
+        # --- Step 2: After controller event selection ---
+        # (In real IDLE, controller uses _prefer_user_events or target file from RPC.)
+        filtered_events = _filter_user_events(raw_events, script_path)
+        print("=" * 60)
+        print("STEP 2: After controller filter (_prefer_user_events)")
+        print("=" * 60)
+        print(f"Count: {len(filtered_events)}")
+        if filtered_events:
+            print("\nFirst filtered event (full):")
+            pprint(filtered_events[0])
+        print()
+
+        # --- Step 3: Steps from pipeline (what UI receives) ---
+        events_for_steps = filtered_events if filtered_events else raw_events
+        steps = events_to_steps(events_for_steps)
+        self.assertGreater(len(steps), 0, "pipeline should produce at least one step")
+
+        print("=" * 60)
+        print("STEP 3: Steps from pipeline (events_to_steps) → same as set_steps(…) in UI")
+        print("=" * 60)
+        print(f"Count: {len(steps)}")
+        print("\nFirst step (full):")
+        pprint(steps[0])
+        if len(steps) > 1:
+            print("\nSecond step (full):")
+            pprint(steps[1])
+        print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -580,15 +580,24 @@ class Executive:
             self.autocomplete = autocomplete.AutoComplete()
         else:
             self.locals = {}
+        self._timeline_trace_config = None
 
     def runcode(self, code):
         global interruptible
+        timeline_started = False
         try:
             self.user_exc_info = None
             interruptible = True
+            if self._timeline_trace_config:
+                from idlelib import timeline_tracer
+                timeline_tracer.start(**self._timeline_trace_config)
+                timeline_started = True
             try:
                 exec(code, self.locals)
             finally:
+                if timeline_started:
+                    from idlelib import timeline_tracer
+                    timeline_tracer.stop()
                 interruptible = False
         except SystemExit as e:
             if e.args:  # SystemExit called with an argument.
@@ -637,22 +646,23 @@ class Executive:
         capture_globals: bool = True,
         max_snapshot_items: int = 25,
         max_repr: int = 200,
+        trace_threads: bool = True,
     ):
-        from idlelib import timeline_tracer
-
-        timeline_tracer.start(
-            max_events=max_events,
-            on_overflow=on_overflow,
-            capture_locals=capture_locals,
-            capture_globals=capture_globals,
-            max_snapshot_items=max_snapshot_items,
-            max_repr=max_repr,
-        )
+        self._timeline_trace_config = {
+            "max_events": max_events,
+            "on_overflow": on_overflow,
+            "capture_locals": capture_locals,
+            "capture_globals": capture_globals,
+            "max_snapshot_items": max_snapshot_items,
+            "max_repr": max_repr,
+            "trace_threads": trace_threads,
+        }
         return True
 
     def stop_timeline_tracing(self):
         from idlelib import timeline_tracer
 
+        self._timeline_trace_config = None
         timeline_tracer.stop()
         return True
 
@@ -666,6 +676,14 @@ class Executive:
         from idlelib import timeline_tracer
 
         return timeline_tracer.get_events()
+
+    def get_timeline_target_file(self):
+        """Return current user script path when available."""
+        try:
+            filename = self.locals.get("__file__")
+        except Exception:
+            return ""
+        return filename if isinstance(filename, str) else ""
 
     def timeline_tracing_status(self):
         from idlelib import timeline_tracer

--- a/Lib/idlelib/timeline_controller.py
+++ b/Lib/idlelib/timeline_controller.py
@@ -8,6 +8,9 @@ activated when the user toggles "Timeline" in the Debug menu.
 
 from __future__ import annotations
 
+import os
+from typing import Any
+
 try:
     from idlelib.timeline_pipeline import events_to_steps
     from idlelib.timeline_ui import TimelinePanel
@@ -16,8 +19,19 @@ except Exception:
     from timeline_ui import TimelinePanel  # type: ignore[no-redef]
 
 
+_LIB_ROOT = os.path.normcase(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+) + os.sep
+
+
 class TimelineController:
     """Manage timeline tracing, data fetching, and UI updates."""
+    _INTERNAL_MARKERS = (
+        os.sep + "lib" + os.sep + "python",
+        "site-packages",
+        os.sep + "idlelib" + os.sep,
+        "importlib",
+    )
 
     def __init__(self, pyshell) -> None:
         self.pyshell = pyshell
@@ -79,10 +93,12 @@ class TimelineController:
             return
         try:
             self._rpc("clear_timeline_events")
+            self.panel.clear()
             self._rpc(
                 "start_timeline_tracing",
                 max_events=2000,
                 capture_globals=False,
+                trace_threads=False,
             )
             self._tracing = True
         except Exception:
@@ -110,13 +126,67 @@ class TimelineController:
         if not self.is_open:
             return
         try:
-            events = self._rpc("get_timeline_events") or []
+            raw_events = self._rpc("get_timeline_events") or []
         except Exception:
-            events = []
+            raw_events = []
+        events = self._select_events_for_display(raw_events)
+        if not events:
+            return
         steps = events_to_steps(events)
         self.panel.set_steps(steps)
         if steps:
             self.panel.select_step(0)
+
+    def _select_events_for_display(self, events):
+        """Select user-code events, prioritizing the active script file."""
+        target = self._get_target_filename()
+        if target:
+            wanted = os.path.normcase(os.path.abspath(target))
+            matches = []
+            for event in events:
+                filename = event.get("filename")
+                if not isinstance(filename, str) or not filename:
+                    continue
+                normed = os.path.normcase(os.path.abspath(filename))
+                if normed == wanted:
+                    matches.append(event)
+            if matches:
+                return matches
+        return self._prefer_user_events(events)
+
+    def _get_target_filename(self) -> str:
+        try:
+            filename = self._rpc("get_timeline_target_file") or ""
+        except Exception:
+            filename = ""
+        return filename if isinstance(filename, str) else ""
+
+    def _prefer_user_events(self, events):
+        """Return only user-code events.
+
+        The tracer currently observes all subprocess activity, including IDLE RPC
+        internals. This filter keeps timeline output focused on user scripts by
+        excluding events sourced from the repository's `Lib/` tree. If no
+        user events are present in this batch, return an empty list so callers
+        can skip replacing the UI with internal-only noise.
+        """
+        user_events = [e for e in events if self._is_user_event(e)]
+        return user_events
+
+    def _is_user_event(self, event) -> bool:
+        filename = event.get("filename")
+        if not isinstance(filename, str) or not filename:
+            return False
+        if filename.startswith("<"):
+            return False
+        normed = os.path.normcase(os.path.abspath(filename))
+        if normed.startswith(_LIB_ROOT):
+            return False
+        lower = normed.lower()
+        for marker in self._INTERNAL_MARKERS:
+            if marker in lower:
+                return False
+        return True
 
     def _on_step_select(self, index: int, step: dict) -> None:
         """Callback invoked when the user clicks a step in the panel."""


### PR DESCRIPTION
## Summary
Fix Timeline capture so it consistently shows user script execution instead of RPC/internal noise.

- Start/stop tracing in the same execution thread as `Executive.runcode()` to capture the actual F5 target script.
- Prioritize events matching the active script path (`__file__`) when populating the Timeline panel.
- Add controller-side fallback/filtering behavior to keep Timeline output focused on user-code events.
- Add regression coverage in `test_timeline_controller.py` for event selection behavior.

## Test plan
- Run: `./python.exe -m unittest -v idlelib.idle_test.test_timeline_tracer idlelib.idle_test.test_timeline_store idlelib.idle_test.test_timeline_pipeline idlelib.idle_test.test_timeline_controller`
- Manual:
  - Launch IDLE with Timeline enabled
  - Run a simple script via F5
  - Verify step list contains user script lines (not `rpc.py` internals)
  - Verify locals/diff update correctly per selected step